### PR TITLE
Add predicate to count() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 lib/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.4
+
+## features
+
+* Enhance the **count** function to count the number of objects matching a predicate. ([@GDarchen](https://github.com/gdarchen))
+  
 # 1.0.3
 
 ## features

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,17 +1,17 @@
 # API
 
-## count(array, item)
+## count(array, toCount)
 
 This function returns the number of occurrences of the specified value in the array provided.
 
 ### Arguments
 
-- **array (Array<number | string | boolean>)**: the array to process.
-- **item (number | string | boolean)**: the item to count.
+- **array (Array<number | string | boolean | object>)**: the array to process.
+- **toCount (number | string | boolean | Function)**: the item to count or the predicate function to apply on each item.
 
 ### returns
 
-- **(number)**: the number of occurrences of item in array.
+- **(number)**: the number of occurrences of item in array or the number of items satisfying the predicate condition.
 
 ### Examples
 
@@ -22,6 +22,8 @@ count([4, 2, 3, 4], 42);
 // => 0
 count(["js-extra", "rocks", "hello", "js-extra", "js-extra"], "js-extra");
 // => 3
+count([{ id: 1, name: "js" }, { id: 2, name: "extra" }, { id: 3, name: "js" }], (item) => item.name === "js");
+// => 2
 ```
 
 ## isAlpha(value)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-extra",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Does what native Javascript doesn't.",
   "homepage": "https://js-extra.netlify.com/",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "author": "Alexandre Le Lain <lelain.alexandre@gmail.com>",
   "contributors": [
-    "Vincent Lacour (https://github.com/LacourVincent)"
+    "Vincent Lacour (https://github.com/LacourVincent)",
+    "Gautier Darchen (https://github.com/gdarchen)"
   ],
   "license": "MIT",
   "keywords": [

--- a/src/count/index.ts
+++ b/src/count/index.ts
@@ -2,12 +2,20 @@
  * This function counts and returns the number of occurences of the value
  * itemToCount in the array provided.
  */
-const count = (array: Array<number | string | boolean>, itemToCount: number | string | boolean): number | null => {
+
+const count = (
+  array: Array<number | string | boolean | object>,
+  toCount: number | string | boolean | ((item: object) => boolean),
+): number | null => {
   try {
-    return array.reduce(
-      (itemCounts: number, item: number | string | boolean) => (itemCounts += item === itemToCount ? 1 : 0),
-      0,
-    );
+    if (isArrayContainingSomeObjects(array) && toCount instanceof Function) {
+      const arrayOfObject = array as object[];
+      return countByPredicate(arrayOfObject, toCount);
+    }
+
+    const arrayOfBasicType = array as Array<number | string | boolean>;
+    const itemToCount = toCount as (number | string | boolean);
+    return countElement(arrayOfBasicType, itemToCount);
   } catch (e) {
     if (!Array.isArray(array)) {
       throw new Error(
@@ -16,6 +24,24 @@ const count = (array: Array<number | string | boolean>, itemToCount: number | st
     }
     throw e;
   }
+};
+
+const countByPredicate = (array: object[], toCount: (item: object) => boolean): number | null => {
+  return array.reduce((itemCounts: number, item: object) => (itemCounts += toCount(item) ? 1 : 0), 0);
+};
+
+const countElement = (
+  array: Array<number | string | boolean>,
+  itemToCount: number | string | boolean,
+): number | null => {
+  return array.reduce(
+    (itemCounts: number, item: number | string | boolean) => (itemCounts += item === itemToCount ? 1 : 0),
+    0,
+  );
+};
+
+const isArrayContainingSomeObjects = (array: Array<number | string | boolean | object>): boolean => {
+  return Array.isArray(array) && array.length > 0 && array.some(item => typeof item === 'object');
 };
 
 export default count;

--- a/src/count/tests/count.test.ts
+++ b/src/count/tests/count.test.ts
@@ -1,5 +1,5 @@
 import count from '../';
-import { BOOLEAN_ARRAY, NUMBER_ARRAY, STRING_ARRAY } from './mocks';
+import { BOOLEAN_ARRAY, NUMBER_ARRAY, STRING_ARRAY, OBJECT_ARRAY, RANDOM_TYPED_ARRAY } from './mocks';
 
 // Array<number> tests
 test('count(NUMBER_ARRAY, 1) to equal 2', () => {
@@ -12,6 +12,10 @@ test('count(NUMBER_ARRAY, 42) to equal 0', () => {
 
 test('count(NUMBER_ARRAY, 5) to equal 3', () => {
   expect(count(NUMBER_ARRAY, 5)).toBe(3);
+});
+
+test('count(NUMBER_ARRAY, (item) => item.name === "js") to equal 0', () => {
+  expect(count(NUMBER_ARRAY, item => item.name === 'js')).toBe(0);
 });
 
 // Array<string> tests
@@ -27,6 +31,10 @@ test('count(STRING_ARRAY, "world") to equal 3', () => {
   expect(count(STRING_ARRAY, 'world')).toBe(3);
 });
 
+test('count(STRING_ARRAY, (item) => item.name === "js") to equal 0', () => {
+  expect(count(STRING_ARRAY, item => item.name === 'js')).toBe(0);
+});
+
 // Array<boolean> tests
 test('count(BOOLEAN_ARRAY, true) to equal 3', () => {
   expect(count(BOOLEAN_ARRAY, true)).toBe(3);
@@ -38,6 +46,36 @@ test('count(BOOLEAN_ARRAY, 42) to equal 0', () => {
 
 test('count(BOOLEAN_ARRAY, false) to equal 1', () => {
   expect(count(BOOLEAN_ARRAY, false)).toBe(1);
+});
+
+test('count(BOOLEAN_ARRAY, (item) => item.name === "js") to equal 0', () => {
+  expect(count(BOOLEAN_ARRAY, item => item.name === 'js')).toBe(0);
+});
+
+// Array<object> tests
+test('count(OBJECT_ARRAY, (item) => item.name === "js") to equal 2', () => {
+  expect(count(OBJECT_ARRAY, item => item.name === 'js')).toBe(2);
+});
+
+test('count(OBJECT_ARRAY, 42) to equal 0', () => {
+  expect(count(OBJECT_ARRAY, 42)).toBe(0);
+});
+
+test('count(OBJECT_ARRAY, () => null to equal 0', () => {
+  expect(count(OBJECT_ARRAY, () => null)).toBe(0);
+});
+
+test('count(OBJECT_ARRAY, () => true to equal OBJECT_ARRAY.length', () => {
+  expect(count(OBJECT_ARRAY, () => true)).toBe(OBJECT_ARRAY.length);
+});
+
+// Array<any>
+test('count(RANDOM_TYPED_ARRAY, (item) => item.name === "js" to equal 2', () => {
+  expect(count(RANDOM_TYPED_ARRAY, item => item.name === 'js')).toBe(2);
+});
+
+test('count(RANDOM_TYPED_ARRAY, "TS" to equal 2', () => {
+  expect(count(RANDOM_TYPED_ARRAY, 'TS')).toBe(1);
 });
 
 //Exceptions tests

--- a/src/count/tests/mocks.ts
+++ b/src/count/tests/mocks.ts
@@ -3,3 +3,7 @@ export const NUMBER_ARRAY = [1, 5, 7, 4, 6, 1, 5, 5];
 export const STRING_ARRAY = ['hello', 'world', 'world', 'JS rocks', 'TS rocks better', 'hello', 'world'];
 
 export const BOOLEAN_ARRAY = [true, true, false, true];
+
+export const OBJECT_ARRAY = [{ id: 1, name: 'js' }, { id: 2, name: 'extra' }, { id: 3, name: 'js' }];
+
+export const RANDOM_TYPED_ARRAY = [{ id: 1, name: 'js' }, 'TS', { id: 2, name: 'js' }];


### PR DESCRIPTION
Fixes #2 

# Description

The `count` method used to only accept arrays containing either `number`, `boolean`, or `string` objects and enabled to count the number of occurences of some item of those types.

I updated this method so as to enable to count the number of items matching a predicate in an array containing some objects.

For instance:
```typescript
const arrayOfMultipleTypes = [{ id: 1, name: "js" }, "TS" , { id: 2, name: "js" }];
count(arrayOfMultipleTypes, (item) => item.name === "js");
// => 2
```